### PR TITLE
Metadata check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/awslabs/cloudwatch-adapter-for-k8s/issues), or [recently closed](https://github.com/awslabs/cloudwatch-adapter-for-k8s/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
+When filing an issue, please check [existing open](https://github.com/cronofy/cloudwatch-adapter-for-k8s/issues), or [recently closed](https://github.com/cronofy/cloudwatch-adapter-for-k8s/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
@@ -41,7 +41,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/cloudwatch-adapter-for-k8s/labels/help%20wanted) issues is a great place to start.
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/cronofy/cloudwatch-adapter-for-k8s/labels/help%20wanted) issues is a great place to start.
 
 
 ## Code of Conduct
@@ -56,6 +56,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awslabs/cloudwatch-adapter-for-k8s/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/cronofy/cloudwatch-adapter-for-k8s/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.14-alpine as builder
 RUN apk add -U --no-cache ca-certificates
-WORKDIR ${GOPATH}/src/github.com/awslabs/k8s-cloudwatch-adapter
+WORKDIR ${GOPATH}/src/github.com/cronofy/k8s-cloudwatch-adapter
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -tags=netgo -o /adapter cmd/adapter/adapter.go
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REGISTRY?=chankh
+REGISTRY?=cronofy
 IMAGE?=k8s-cloudwatch-adapter
 TEMP_DIR:=$(shell mktemp -d /tmp/$(IMAGE).XXXXXX)
 ARCH?=amd64
@@ -21,7 +21,7 @@ $(OUT_DIR)/%/adapter: $(SRC)
 docker-build: verify-apis test
 	cp deploy/Dockerfile $(TEMP_DIR)/Dockerfile
 
-	docker run --rm -v $(TEMP_DIR):/build -v $(shell pwd):/go/src/github.com/awslabs/k8s-cloudwatch-adapter -e GOARCH=$(ARCH) -e GOFLAGS="$(GOFLAGS)" -w /go/src/github.com/awslabs/k8s-cloudwatch-adapter $(GOIMAGE) /bin/bash -c "\
+	docker run --rm -v $(TEMP_DIR):/build -v $(shell pwd):/go/src/github.com/cronofy/k8s-cloudwatch-adapter -e GOARCH=$(ARCH) -e GOFLAGS="$(GOFLAGS)" -w /go/src/github.com/cronofy/k8s-cloudwatch-adapter $(GOIMAGE) /bin/bash -c "\
 		CGO_ENABLED=0 GO111MODULE=on go build -o /build/adapter cmd/adapter/adapter.go"
 
 	docker build -t $(REGISTRY)/$(IMAGE):$(VERSION) $(TEMP_DIR)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-[![Build Status](https://travis-ci.org/awslabs/k8s-cloudwatch-adapter.svg?branch=master)](https://travis-ci.org/awslabs/k8s-cloudwatch-adapter)
 [![GitHub
-release](https://img.shields.io/github/release/awslabs/k8s-cloudwatch-adapter/all.svg)](https://github.com/awslabs/k8s-cloudwatch-adapter/releases)
+release](https://img.shields.io/github/release/cronofy/k8s-cloudwatch-adapter/all.svg)](https://github.com/cronofy/k8s-cloudwatch-adapter/releases)
 [![docker image
-size](https://shields.beevelop.com/docker/image/image-size/chankh/k8s-cloudwatch-adapter/latest.svg)](https://hub.docker.com/r/chankh/k8s-cloudwatch-adapter)
+size](https://shields.beevelop.com/docker/image/image-size/cronofy/k8s-cloudwatch-adapter/latest.svg)](https://hub.docker.com/r/cronofy/k8s-cloudwatch-adapter)
 [![image
-layers](https://shields.beevelop.com/docker/image/layers/chankh/k8s-cloudwatch-adapter/latest.svg)](https://hub.docker.com/r/chankh/k8s-cloudwatch-adapter)
+layers](https://shields.beevelop.com/docker/image/layers/cronofy/k8s-cloudwatch-adapter/latest.svg)](https://hub.docker.com/r/cronofy/k8s-cloudwatch-adapter)
 [![image
-pulls](https://shields.beevelop.com/docker/pulls/chankh/k8s-cloudwatch-adapter.svg)](https://hub.docker.com/r/chankh/k8s-cloudwatch-adapter)
+pulls](https://shields.beevelop.com/docker/pulls/cronofy/k8s-cloudwatch-adapter.svg)](https://hub.docker.com/r/cronofy/k8s-cloudwatch-adapter)
 
 # Kubernetes Custom Metrics Adapter for Kubernetes
 
@@ -47,7 +46,7 @@ Requires a Kubernetes cluster with Metric Server deployed, Amazon EKS cluster is
 Now deploy the adapter to your Kubernetes cluster:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/awslabs/k8s-cloudwatch-adapter/master/deploy/adapter.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/cronofy/k8s-cloudwatch-adapter/master/deploy/adapter.yaml
 namespace/custom-metrics created
 clusterrolebinding.rbac.authorization.k8s.io/k8s-cloudwatch-adapter:system:auth-delegator created
 rolebinding.rbac.authorization.k8s.io/k8s-cloudwatch-adapter-auth-reader created
@@ -115,4 +114,4 @@ Refer to this [guide](samples/sqs/README.md).
 This library is licensed under the Apache 2.0 License.
 
 ## Issues
-Report any issues in the [Github Issues](https://github.com/awslabs/k8s-cloudwatch-adapter/issues)
+Report any issues in the [Github Issues](https://github.com/cronofy/k8s-cloudwatch-adapter/issues)

--- a/charts/k8s-cloudwatch-adapter/values.yaml
+++ b/charts/k8s-cloudwatch-adapter/values.yaml
@@ -1,6 +1,6 @@
 image:
   pullPolicy: IfNotPresent
-  repository: chankh/k8s-cloudwatch-adapter
+  repository: cronofy/k8s-cloudwatch-adapter
   tag: "v0.10.0"
 
 ## Optional array of imagePullSecrets containing private registry credentials

--- a/cmd/adapter/adapter.go
+++ b/cmd/adapter/adapter.go
@@ -9,12 +9,12 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
 
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/aws"
-	clientset "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
-	informers "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/controller"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/metriccache"
-	cwprov "github.com/awslabs/k8s-cloudwatch-adapter/pkg/provider"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/aws"
+	clientset "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
+	informers "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/controller"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/metriccache"
+	cwprov "github.com/cronofy/k8s-cloudwatch-adapter/pkg/provider"
 	basecmd "github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/cmd"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 )

--- a/deploy/adapter.yaml
+++ b/deploy/adapter.yaml
@@ -53,7 +53,7 @@ spec:
         fsGroup: 65534
       containers:
       - name: k8s-cloudwatch-adapter
-        image: chankh/k8s-cloudwatch-adapter:v0.10.0
+        image: cronofy/k8s-cloudwatch-adapter:v0.10.0
         args:
         - /adapter
         - --cert-dir=/tmp

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/awslabs/k8s-cloudwatch-adapter
+module github.com/cronofy/k8s-cloudwatch-adapter
 
 go 1.14
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -13,8 +13,8 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-ge
 #                  instead of the $GOPATH directly. For normal projects this can be dropped.
 chmod +x ${CODEGEN_PKG}/generate-groups.sh
 ${CODEGEN_PKG}/generate-groups.sh "all" \
-    github.com/awslabs/k8s-cloudwatch-adapter/pkg/client \
-    github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis \
+    github.com/cronofy/k8s-cloudwatch-adapter/pkg/client \
+    github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis \
     metrics:v1alpha1 \
     --go-header-file "$(dirname ${BASH_SOURCE})/custom-boilerplate.go.txt" \
     --output-base "$(dirname ${BASH_SOURCE})/../../../.."

--- a/pkg/apis/metrics/v1alpha1/register.go
+++ b/pkg/apis/metrics/v1alpha1/register.go
@@ -5,7 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	externalmetric "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics"
+	externalmetric "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics"
 )
 
 // SchemeGroupVersion is the group version used to register these objects

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/pkg/aws/interface.go
+++ b/pkg/aws/interface.go
@@ -2,7 +2,7 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 )
 
 // CloudWatchManager manages clients for Amazon CloudWatch.

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -18,8 +18,13 @@ func GetLocalRegion() string {
 		klog.Errorf("unable to get current region information, %v", err)
 		return ""
 	}
-
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		klog.Errorf("unable to get current region information, status code %v", resp.StatusCode)
+		return ""
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		klog.Errorf("cannot read response from instance metadata, %v", err)

--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 
 	"k8s.io/klog"
 )

--- a/pkg/aws/util_test.go
+++ b/pkg/aws/util_test.go
@@ -6,7 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/aws-sdk-go/aws"
-	api "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	api "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 )
 
 func TestToCloudWatchQuery(t *testing.T) {

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -18,7 +18,7 @@ package versioned
 import (
 	"fmt"
 
-	metricsv1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
+	metricsv1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -16,9 +16,9 @@
 package fake
 
 import (
-	clientset "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
-	metricsv1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
-	fakemetricsv1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake"
+	clientset "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
+	metricsv1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
+	fakemetricsv1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -16,7 +16,7 @@
 package fake
 
 import (
-	metricsv1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	metricsv1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -16,7 +16,7 @@
 package scheme
 
 import (
-	metricsv1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	metricsv1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/metrics/v1alpha1/externalmetric.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1alpha1/externalmetric.go
@@ -18,8 +18,8 @@ package v1alpha1
 import (
 	"time"
 
-	v1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
-	scheme "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	scheme "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"

--- a/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_externalmetric.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_externalmetric.go
@@ -16,7 +16,7 @@
 package fake
 
 import (
-	v1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	v1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_metrics_client.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_metrics_client.go
@@ -16,7 +16,7 @@
 package fake
 
 import (
-	v1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
+	v1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/typed/metrics/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -16,8 +16,8 @@
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
 )
 

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -20,9 +20,9 @@ import (
 	sync "sync"
 	time "time"
 
-	versioned "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/internalinterfaces"
-	metrics "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/metrics"
+	versioned "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/internalinterfaces"
+	metrics "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/metrics"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -18,7 +18,7 @@ package externalversions
 import (
 	"fmt"
 
-	v1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	v1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -18,7 +18,7 @@ package internalinterfaces
 import (
 	time "time"
 
-	versioned "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
+	versioned "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/informers/externalversions/metrics/interface.go
+++ b/pkg/client/informers/externalversions/metrics/interface.go
@@ -16,8 +16,8 @@
 package metrics
 
 import (
-	internalinterfaces "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/metrics/v1alpha1"
+	internalinterfaces "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/metrics/v1alpha1"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/metrics/v1alpha1/externalmetric.go
+++ b/pkg/client/informers/externalversions/metrics/v1alpha1/externalmetric.go
@@ -18,10 +18,10 @@ package v1alpha1
 import (
 	time "time"
 
-	metricsv1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
-	versioned "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/listers/metrics/v1alpha1"
+	metricsv1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	versioned "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/listers/metrics/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/metrics/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/metrics/v1alpha1/interface.go
@@ -16,7 +16,7 @@
 package v1alpha1
 
 import (
-	internalinterfaces "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/listers/metrics/v1alpha1/externalmetric.go
+++ b/pkg/client/listers/metrics/v1alpha1/externalmetric.go
@@ -16,7 +16,7 @@
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	v1alpha1 "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
-	informers "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	informers "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions/metrics/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	api "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/fake"
-	informers "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions"
+	api "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/fake"
+	informers "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -3,8 +3,8 @@ package controller
 import (
 	"fmt"
 
-	listers "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/listers/metrics/v1alpha1"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/metriccache"
+	listers "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/listers/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/metriccache"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	api "github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/metriccache"
+	api "github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/metriccache"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/fake"
-	informers "github.com/awslabs/k8s-cloudwatch-adapter/pkg/client/informers/externalversions"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/clientset/versioned/fake"
+	informers "github.com/cronofy/k8s-cloudwatch-adapter/pkg/client/informers/externalversions"
 )
 
 func getExternalKey(externalMetric *api.ExternalMetric) namespacedQueueItem {

--- a/pkg/metriccache/metric_cache.go
+++ b/pkg/metriccache/metric_cache.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/apis/metrics/v1alpha1"
 
 	"k8s.io/klog"
 )

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -6,8 +6,8 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/aws"
-	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/metriccache"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/aws"
+	"github.com/cronofy/k8s-cloudwatch-adapter/pkg/metriccache"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 )
 

--- a/samples/sqs/Makefile
+++ b/samples/sqs/Makefile
@@ -5,6 +5,6 @@ build:
 clean:
 	go clean && rm -rf ./bin
 consumer-container:
-	docker build -t chankh/sqs-consumer-sample ./consumer
+	docker build -t cronofy/sqs-consumer-sample ./consumer
 producer-container:
-	docker build -t chankh/sqs-producer-sample ./producer
+	docker build -t cronofy/sqs-producer-sample ./producer

--- a/samples/sqs/consumer/main.go
+++ b/samples/sqs/consumer/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	util "github.com/awslabs/k8s-cloudwatch-adapter/pkg/aws"
+	util "github.com/cronofy/k8s-cloudwatch-adapter/pkg/aws"
 )
 
 func main() {

--- a/samples/sqs/deploy/consumer-deployment.yaml
+++ b/samples/sqs/deploy/consumer-deployment.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
       - name: sqs-consumer
-        image: chankh/sqs-consumer-sample
+        image: cronofy/sqs-consumer-sample

--- a/samples/sqs/deploy/producer-deployment.yaml
+++ b/samples/sqs/deploy/producer-deployment.yaml
@@ -15,4 +15,4 @@ spec:
     spec:
       containers:
       - name: sqs-producer
-        image: chankh/sqs-producer-sample
+        image: cronofy/sqs-producer-sample

--- a/samples/sqs/producer/main.go
+++ b/samples/sqs/producer/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	util "github.com/awslabs/k8s-cloudwatch-adapter/pkg/aws"
+	util "github.com/cronofy/k8s-cloudwatch-adapter/pkg/aws"
 )
 
 func main() {


### PR DESCRIPTION
The real change is in the first commit 3aa840d0d83ec327298be03e28fa5e4c7bd24a92, the rest is updating references to match this repository and https://hub.docker.com/r/cronofy/k8s-cloudwatch-adapter for publishing.